### PR TITLE
use count type for some metrics.

### DIFF
--- a/lib/metrics/grouping.rb
+++ b/lib/metrics/grouping.rb
@@ -15,7 +15,7 @@ module Metrics
     end
 
     def increment(metric)
-      instrument metric, 1
+      instrument metric, 1, type: 'count'
     end
 
     def instrument(metric, *args, &block)

--- a/lib/rack/instrumentation.rb
+++ b/lib/rack/instrumentation.rb
@@ -16,7 +16,7 @@ module Rack
 
         response
       rescue Exception => raised
-        instrument 'exception', 1, source: 'rack'
+        instrument 'exception', 1, source: 'rack', type: 'count'
         raise
       end
     end


### PR DESCRIPTION
for `exception.count` and counts of status codes.
