### PR TITLE
Underscore the metric namespace.

### DIFF
--- a/lib/metrics.rb
+++ b/lib/metrics.rb
@@ -1,4 +1,5 @@
 require 'rack/instrumentation'
+require 'metrics/core_ext'
 require 'metrics/railtie' if defined?(Rails)
 
 module Metrics

--- a/lib/metrics/core_ext.rb
+++ b/lib/metrics/core_ext.rb
@@ -1,0 +1,9 @@
+class String
+  def underscore
+    self.gsub(/::/, '/').
+      gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2').
+      gsub(/([a-z\d])([A-Z])/,'\1_\2').
+      tr("-", "_").
+      downcase
+  end unless method_defined?(:underscore)
+end

--- a/lib/metrics/instrumentable.rb
+++ b/lib/metrics/instrumentable.rb
@@ -38,7 +38,7 @@ module Metrics
       #
       # Returns a String namespace for the metric.
       def metric_namespace
-        to_s.gsub(/::/, '.').downcase
+        to_s.gsub(/::/, '.').underscore
       end
 
       # Public: Wraps the method with a call to instrument the duration of the

--- a/spec/metrics/instrumentable_spec.rb
+++ b/spec/metrics/instrumentable_spec.rb
@@ -6,7 +6,7 @@ describe Metrics::Instrumentable do
       include Metrics::Instrumentable
 
       def self.to_s
-        'Some::Module'
+        'SomeCrazy::Module'
       end
 
       def initialize
@@ -29,7 +29,7 @@ describe Metrics::Instrumentable do
 
   describe '#instrument' do
     it 'instruments the duration of the method' do
-      klass.any_instance.should_receive(:instrument).with('some.module.long_method').and_yield
+      klass.any_instance.should_receive(:instrument).with('some_crazy.module.long_method').and_yield
       expect(klass.new.long_method).to eq 'foo'
     end
 


### PR DESCRIPTION
So a class or module ThatIsCamelCased will turn into something readable:

```
that_is_camel_cased.method
```

vs

```
thatiscamelcased.method
```
