### PR TITLE
Use rack.exception as metric name.

### DIFF
--- a/lib/rack/instrumentation.rb
+++ b/lib/rack/instrumentation.rb
@@ -20,7 +20,7 @@ module Rack
 
         response
       rescue Exception => raised
-        instrument 'exception', 1, source: 'rack', type: 'count'
+        instrument 'rack.exception', 1, type: 'count'
         raise
       end
     end


### PR DESCRIPTION
I'm going to move the `exception` metric into an [exceptions](https://github.com/remind101/exceptions) handler, so our metrics would be:
- `exception`: Incremented on any call to `Exceptions.notify`
- `rack.exception`: Incremented when there's an exception within a rack request.
- `sidekiq.exception`: Incremented when there's an exception within a sidekiq job.
