### PR TITLE
DogStatsD driver with tag support

### DIFF
--- a/lib/metrics.rb
+++ b/lib/metrics.rb
@@ -15,6 +15,7 @@ module Metrics
     autoload :Base,            'metrics/drivers/base'
     autoload :L2Met,           'metrics/drivers/l2met'
     autoload :Statsd,          'metrics/drivers/statsd'
+    autoload :DogStatsd,       'metrics/drivers/dog_statsd'
   end
 
   module Helpers

--- a/lib/metrics/drivers/dog_statsd.rb
+++ b/lib/metrics/drivers/dog_statsd.rb
@@ -25,7 +25,7 @@ module Metrics::Drivers
     private
 
     def formatted_tags(tags)
-      tags.map { |k, v| "%s:%s" % [k, v.tr(' ', '_')] }
+      tags.map { |k, v| "%s:%s" % [k, v.to_s.tr(' ', '_')] }
     end
 
   end

--- a/lib/metrics/drivers/dog_statsd.rb
+++ b/lib/metrics/drivers/dog_statsd.rb
@@ -25,7 +25,7 @@ module Metrics::Drivers
     private
 
     def formatted_tags(tags)
-      tags.map { |k, v| "%s:%s" % [k, v] }
+      tags.map { |k, v| "%s:%s" % [k, v.tr(' ', '_')] }
     end
 
   end

--- a/lib/metrics/drivers/dog_statsd.rb
+++ b/lib/metrics/drivers/dog_statsd.rb
@@ -1,0 +1,32 @@
+module Metrics::Drivers
+  class DogStatsd < Statsd
+
+    def emit(instrumenter)
+      name = name_for(instrumenter)
+      value = instrumenter.value
+      tags = formatted_tags(instrumenter.tags)
+
+      case instrumenter.type
+        when 'histogram'
+          client.histogram(name, value, tags: tags)
+        when 'measure', 'sample'
+          if instrumenter.units == 'ms'
+            client.timing(name, value, tags: tags)
+          else
+            client.gauge(name, value, tags: tags)
+          end
+        when 'count'
+          client.count(name, value, tags: tags)
+        else
+          raise ArgumentError.new("unsupported instrumenter type for dogstatsd: '%s'" % instrumenter.type)
+      end
+    end
+
+    private
+
+    def formatted_tags(tags)
+      tags.map { |k, v| "%s:%s" % [k, v] }
+    end
+
+  end
+end

--- a/lib/metrics/instrumenter.rb
+++ b/lib/metrics/instrumenter.rb
@@ -46,6 +46,10 @@ module Metrics
       options[:source]
     end
 
+    def tags
+      options[:tags] || {}
+    end
+
     def result
       return nil unless block
       return @result if defined?(@result)

--- a/spec/metrics/drivers/dog_statsd_spec.rb
+++ b/spec/metrics/drivers/dog_statsd_spec.rb
@@ -27,8 +27,8 @@ describe Metrics::Drivers::DogStatsd do
       end
 
       it 'should pass multiple tags to the dogstatsd-ruby client' do
-        client.should_receive(:count).with('foo.bar.source__app__', 10, tags: ['tag0:value0', 'tag1:value1', 'tag2:value2'])
-        write(instrumenter('foo.bar', 10, type: 'count', tags: {tag0: 'value0', tag1: 'value1', tag2: 'value2'}))
+        client.should_receive(:count).with('foo.bar.source__app__', 10, tags: ['tag0:value0', 'tag1:a_tag_value', 'tag2:2222'])
+        write(instrumenter('foo.bar', 10, type: 'count', tags: {tag0: 'value0', tag1: :a_tag_value, tag2: 2222}))
       end
     end
 

--- a/spec/metrics/drivers/dog_statsd_spec.rb
+++ b/spec/metrics/drivers/dog_statsd_spec.rb
@@ -22,8 +22,8 @@ describe Metrics::Drivers::DogStatsd do
       end
 
       it 'should pass a tag to the dogstatsd-ruby client' do
-        client.should_receive(:gauge).with('rack.request.size.source__app__', 10, tags: ['tag0:value0'])
-        write(instrumenter('rack.request.size', 10, type: 'measure', tags: {tag0: 'value0'}))
+        client.should_receive(:gauge).with('rack.request.size.source__app__', 10, tags: ['tag0:long_value_with_lots_of_whitespace'])
+        write(instrumenter('rack.request.size', 10, type: 'measure', tags: {tag0: 'long value with lots of whitespace'}))
       end
 
       it 'should pass multiple tags to the dogstatsd-ruby client' do

--- a/spec/metrics/drivers/dog_statsd_spec.rb
+++ b/spec/metrics/drivers/dog_statsd_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+require 'securerandom'
+
+describe Metrics::Drivers::DogStatsd do
+  let(:client) { double }
+
+  def instrumenter(*args)
+    Metrics::Instrumenter.new(*args)
+  end
+
+  def write(*instrumenters)
+    described_class.new(client, '{{name}}.source__{{source}}__', 'app').write(*instrumenters)
+  end
+
+  describe '.write' do
+
+    context 'tag support' do
+
+      it 'should pass an empty tag array if no tags are given' do
+        client.should_receive(:timing).with('rack.request.time.source__app__', 10.3333, tags: [])
+        write(instrumenter('rack.request.time', 10.3333, units: 'ms', type: 'sample'))
+      end
+
+      it 'should pass a tag to the dogstatsd-ruby client' do
+        client.should_receive(:gauge).with('rack.request.size.source__app__', 10, tags: ['tag0:value0'])
+        write(instrumenter('rack.request.size', 10, type: 'measure', tags: {tag0: 'value0'}))
+      end
+
+      it 'should pass multiple tags to the dogstatsd-ruby client' do
+        client.should_receive(:count).with('foo.bar.source__app__', 10, tags: ['tag0:value0', 'tag1:value1', 'tag2:value2'])
+        write(instrumenter('foo.bar', 10, type: 'count', tags: {tag0: 'value0', tag1: 'value1', tag2: 'value2'}))
+      end
+    end
+
+  end
+end

--- a/spec/metrics/instrumenter_spec.rb
+++ b/spec/metrics/instrumenter_spec.rb
@@ -43,6 +43,19 @@ describe Metrics::Instrumenter do
     end
   end
 
+  describe '.tags' do
+    subject { instrumenter.tags }
+
+    context 'by default' do
+      it {should eq Hash.new }
+    end
+
+    context 'when specified' do
+      let(:instrumenter) { described_class.new('jobs.busy', 10, units: 'jobs', tags: {tag0: 'value0', tag1: 'value1'}) }
+      it {should eq({tag0: 'value0', tag1: 'value1'})}
+    end
+  end
+
   describe '.result' do
     subject { instrumenter.result }
 


### PR DESCRIPTION
DogStatsD is an extension of StatsD that can accept tag arrays.