### PR TITLE
Faraday instrumentation on_complete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.rbc
 .bundle
 .config
+.idea/
 .yardoc
 Gemfile.lock
 InstalledFiles

--- a/lib/faraday/instrumentation.rb
+++ b/lib/faraday/instrumentation.rb
@@ -12,12 +12,11 @@ module Faraday
 
     def call(env)
       time = Time.now
-      response = @app.call(env)
-      duration = (Time.now - time) * 1000.0
-
-      request_metrics response.status, duration, metric: metric, source: source(env)
-
-      response
+      @app.call(env).on_complete do |env|
+        duration = (Time.now - time) * 1000.0
+        response = env[:response]
+        request_metrics response.status, duration, metric: metric, source: source(env)
+      end
     end
 
   private


### PR DESCRIPTION
Per [docs](https://github.com/lostisland/faraday/blame/a5f027e1ce70663563cfd4e68396443701ef1041/README.md#L197-L199) middleware has to do post-response work in a callback to support async calls.

Do I need to bump a version number or something?